### PR TITLE
feat: disable vertical swipe

### DIFF
--- a/example/src/screens/Photos.tsx
+++ b/example/src/screens/Photos.tsx
@@ -40,6 +40,7 @@ export const Photos = () => {
   return (
     <View style={styles.container}>
       <AwesomeGallery
+        disableVerticalSwipe
         data={params.images.map((uri) => ({ uri }))}
         keyExtractor={(item) => item.uri}
         renderItem={renderItem}

--- a/example/src/screens/Photos.tsx
+++ b/example/src/screens/Photos.tsx
@@ -40,7 +40,6 @@ export const Photos = () => {
   return (
     <View style={styles.container}>
       <AwesomeGallery
-        disableVerticalSwipe
         data={params.images.map((uri) => ({ uri }))}
         keyExtractor={(item) => item.uri}
         renderItem={renderItem}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -124,6 +124,7 @@ type Props<T> = EventsCallbacks & {
   doubleTapScale: number;
   maxScale: number;
   disableTransitionOnScaledImage: boolean;
+  disableVerticalSwipe: boolean;
 };
 
 const ResizableImage = React.memo(
@@ -146,6 +147,7 @@ const ResizableImage = React.memo(
     doubleTapScale,
     maxScale,
     disableTransitionOnScaledImage,
+    disableVerticalSwipe,
     length,
   }: Props<T>) => {
     const CENTER = {
@@ -441,6 +443,8 @@ const ResizableImage = React.memo(
         onActive: ({ translationX, translationY, velocityY }, ctx) => {
           if (!isActive.value) return;
           if (pinchActive.value && !isAndroid) return;
+          if (disableVerticalSwipe && scale.value === 1 && ctx.isVertical)
+            return;
 
           const x = getEdgeX();
 
@@ -672,6 +676,7 @@ type GalleryProps<T> = EventsCallbacks & {
   style?: ViewStyle;
   containerDimensions?: { width: number; height: number };
   disableTransitionOnScaledImage?: boolean;
+  disableVerticalSwipe?: boolean;
 };
 
 const GalleryComponent = <T extends any>(
@@ -688,6 +693,7 @@ const GalleryComponent = <T extends any>(
     style,
     keyExtractor,
     containerDimensions,
+    disableVerticalSwipe,
     ...eventsCallbacks
   }: GalleryProps<T>,
   ref: GalleryReactRef
@@ -766,6 +772,7 @@ const GalleryComponent = <T extends any>(
                     doubleTapScale,
                     maxScale,
                     disableTransitionOnScaledImage,
+                    disableVerticalSwipe,
                     ...eventsCallbacks,
                     ...dimensions,
                   }}


### PR DESCRIPTION
Feature:
added ability to disable vertical swipe, when scale is equal  1

Description:
In some cases, you would like to disable this gesture (like in my case). I am using X button to close the gallery so I don't need this gesture. 

How to test it:
just add `disableVerticalSwipe` prop and check, if you can't swipe vertically, when image is not zoomed