### PR TITLE
feat: implement on scale value changed callback

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -126,7 +126,7 @@ type Props<T> = EventsCallbacks & {
   disableTransitionOnScaledImage: boolean;
   disableVerticalSwipe: boolean;
   onScaleChange?: (scale: number) => void;
-  scaleRange?: { start: number; end: number };
+  onScaleChangeRange?: { start: number; end: number };
 };
 
 const ResizableImage = React.memo(
@@ -152,7 +152,7 @@ const ResizableImage = React.memo(
     disableVerticalSwipe,
     length,
     onScaleChange,
-    scaleRange,
+    onScaleChangeRange,
   }: Props<T>) => {
     const CENTER = {
       x: width / 2,
@@ -188,14 +188,14 @@ const ResizableImage = React.memo(
           return;
         }
 
-        if (!scaleRange) {
+        if (!onScaleChangeRange) {
           runOnJS(onScaleChange)(scaleReaction);
           return;
         }
 
         if (
-          scaleReaction > scaleRange.start &&
-          scaleReaction < scaleRange.end
+          scaleReaction > onScaleChangeRange.start &&
+          scaleReaction < onScaleChangeRange.end
         ) {
           runOnJS(onScaleChange)(scaleReaction);
         }
@@ -705,7 +705,7 @@ type GalleryProps<T> = EventsCallbacks & {
   disableTransitionOnScaledImage?: boolean;
   disableVerticalSwipe?: boolean;
   onScaleChange?: (scale: number) => void;
-  scaleRange?: { start: number; end: number };
+  onScaleChangeRange?: { start: number; end: number };
 };
 
 const GalleryComponent = <T extends any>(
@@ -724,7 +724,7 @@ const GalleryComponent = <T extends any>(
     containerDimensions,
     disableVerticalSwipe,
     onScaleChange,
-    scaleRange,
+    onScaleChangeRange,
     ...eventsCallbacks
   }: GalleryProps<T>,
   ref: GalleryReactRef
@@ -805,7 +805,7 @@ const GalleryComponent = <T extends any>(
                     disableTransitionOnScaledImage,
                     disableVerticalSwipe,
                     onScaleChange,
-                    scaleRange,
+                    onScaleChangeRange,
                     ...eventsCallbacks,
                     ...dimensions,
                   }}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -125,6 +125,8 @@ type Props<T> = EventsCallbacks & {
   maxScale: number;
   disableTransitionOnScaledImage: boolean;
   disableVerticalSwipe: boolean;
+  onScaleChange?: (scale: number) => void;
+  scaleRange?: { start: number; end: number };
 };
 
 const ResizableImage = React.memo(
@@ -149,6 +151,8 @@ const ResizableImage = React.memo(
     disableTransitionOnScaledImage,
     disableVerticalSwipe,
     length,
+    onScaleChange,
+    scaleRange,
   }: Props<T>) => {
     const CENTER = {
       x: width / 2,
@@ -174,6 +178,29 @@ const ResizableImage = React.memo(
     const layout = useVector(width, 0);
 
     const isActive = useDerivedValue(() => currentIndex.value === index);
+
+    useAnimatedReaction(
+      () => {
+        return scale.value;
+      },
+      (scaleReaction) => {
+        if (!onScaleChange) {
+          return;
+        }
+
+        if (!scaleRange) {
+          runOnJS(onScaleChange)(scaleReaction);
+          return;
+        }
+
+        if (
+          scaleReaction > scaleRange.start &&
+          scaleReaction < scaleRange.end
+        ) {
+          runOnJS(onScaleChange)(scaleReaction);
+        }
+      }
+    );
 
     const setAdjustedFocal = ({
       focalX,
@@ -677,6 +704,8 @@ type GalleryProps<T> = EventsCallbacks & {
   containerDimensions?: { width: number; height: number };
   disableTransitionOnScaledImage?: boolean;
   disableVerticalSwipe?: boolean;
+  onScaleChange?: (scale: number) => void;
+  scaleRange?: { start: number; end: number };
 };
 
 const GalleryComponent = <T extends any>(
@@ -694,6 +723,8 @@ const GalleryComponent = <T extends any>(
     keyExtractor,
     containerDimensions,
     disableVerticalSwipe,
+    onScaleChange,
+    scaleRange,
     ...eventsCallbacks
   }: GalleryProps<T>,
   ref: GalleryReactRef
@@ -773,6 +804,8 @@ const GalleryComponent = <T extends any>(
                     maxScale,
                     disableTransitionOnScaledImage,
                     disableVerticalSwipe,
+                    onScaleChange,
+                    scaleRange,
                     ...eventsCallbacks,
                     ...dimensions,
                   }}


### PR DESCRIPTION
Feature:
implemented on scale value changed callback, which passes current scale value

Description:
In some cases, you would like to do some action, when scale is more than 0.9 and less than 1.1. In my case I have a thumbnail list at the bottom. These list needs to be hidden, when scale is more than 1 and displayed when scale is more than 0.9 

How to test it:
Just add those two props 
```
        onScaleValueChanged={(scale) => console.log({ scale })}
        scaleRange={{ start: 0.9, end: 1.1 }}
```
and if range is correct 

remove the scaleRange prop and check, if all scale values are logged