### PR TITLE
Fire changeIndex on initialIndex

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -770,9 +770,7 @@ const GalleryComponent = <T extends any>(
   useAnimatedReaction(
     () => currentIndex.value,
     (newIndex) => {
-      if (newIndex !== initialIndex) {
-        runOnJS(changeIndex)(newIndex);
-      }
+      runOnJS(changeIndex)(newIndex);
     }
   );
 


### PR DESCRIPTION
Hi guys! Thanks for the hard work in this library, I am using it in my current project!

While using it, I have faced a problem with not firing `changeIndex(...)` when coming back to the image with `initialIndex`. It breaks the logic when you want to show the current index like `3/10` or when you need to download the current image.