### PR TITLE
fix: ScrollX when there's only one picture

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -554,6 +554,7 @@ const ResizableImage = React.memo(
                 translateX.value =
                   ctx.initialTranslateX + translationX - clampedX;
               } else {
+                if(disableTransitionOnScaledImage && scale.value <= 1 && Math.abs(getPosition(length - 1)) ===0 ) return
                 translateX.value = withRubberBandClamp(
                   ctx.initialTranslateX + translationX - clampedX,
                   0.55,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -554,7 +554,8 @@ const ResizableImage = React.memo(
                 translateX.value =
                   ctx.initialTranslateX + translationX - clampedX;
               } else {
-                if(disableTransitionOnScaledImage && scale.value <= 1 && Math.abs(getPosition(length - 1)) ===0 ) return
+                // if only has one picture, retrun
+                if(Math.abs(getPosition(length - 1)) ===0 )return
                 translateX.value = withRubberBandClamp(
                   ctx.initialTranslateX + translationX - clampedX,
                   0.55,


### PR DESCRIPTION
fix: When I only have one picture , scroll horizontal picture is hidden.
I fix it. 
[Watch the Bug Demo](https://upload.42how.com/article/202108051523-bug.mp4)