### PR TITLE
fix: out of sync onIndexChange

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -936,7 +936,7 @@ const GalleryComponent = <T extends any>(
   useAnimatedReaction(
     () => currentIndex.value,
     (newIndex) => runOnJS(changeIndex)(newIndex),
-    [currentIndex]
+    [currentIndex, changeIndex]
   );
 
   useEffect(() => {


### PR DESCRIPTION
# Description

We have a bug currently where the `onIndexChange` function is always binded to the first reference because it's not included on the `useAnimatedReaction` deps array, so the following code does not work as expected:

```tsx
const [index, setIndex] = useState(0)

return (
  <Gallery
    data={images}
    initialIndex={index}
    onIndexChange={(newIndex) => {
      // will always show "0" even if we call the dispatcher on the following line
      console.log(index)
      setIndex(newIndex)
    }}
  />
);
```

We had the exact same bug on our project today (we're starting using this library), we added patch package for now (with the same change) and it's working now.