### PR TITLE
fix typo 'wprklet' => 'worklet'

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -711,7 +711,7 @@ const ResizableImage = React.memo(
               ],
             },
             () => {
-              'wprklet';
+              'worklet';
               isMoving.x.value = 0;
             }
           );


### PR DESCRIPTION
Don't know if it makes a difference but fixed anyway.