### PR TITLE
Expose `testID` prop on GalleryComponent

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -931,6 +931,8 @@ type GalleryProps<T> = EventsCallbacks & {
   loop?: boolean;
   onScaleChange?: (scale: number) => void;
   onScaleChangeRange?: { start: number; end: number };
+
+  containerTestID?: string
 };
 
 const GalleryComponent = <T extends any>(
@@ -957,6 +959,7 @@ const GalleryComponent = <T extends any>(
     loop = false,
     onScaleChange,
     onScaleChangeRange,
+    containerTestID,
     ...eventsCallbacks
   }: GalleryProps<T>,
   ref: GalleryReactRef
@@ -1034,7 +1037,7 @@ const GalleryComponent = <T extends any>(
 
   return (
     <GestureHandlerRootView style={[styles.container, style]}>
-      <Animated.View style={[styles.rowContainer, animatedStyle]}>
+      <Animated.View style={[styles.rowContainer, animatedStyle]} testID={containerTestID}>
         {data.map((item: any, i) => {
           const isFirst = i === 0;
 


### PR DESCRIPTION
I think it'd be very useful to be able to pass in a test ID for the gallery container for automated testing! So I've created a tiny PR that exposes this prop. To make it clear what the test ID will be applied to, and to follow the naming of other props named `containerXX` I've exposed it as `containerTestID`, but if you think `testID` would be sufficient/better, that's also nice!